### PR TITLE
Improve sauce pan/cauldron firepit interaction

### DIFF
--- a/ACulinaryArtillery.cs
+++ b/ACulinaryArtillery.cs
@@ -12,6 +12,7 @@ namespace ACulinaryArtillery
     public class ACulinaryArtillery : ModSystem
     {
         private static Harmony harmony;
+        public static ILogger logger;
 
         public override void Start(ICoreAPI api)
         {
@@ -73,6 +74,7 @@ namespace ACulinaryArtillery
             }
 
             harmony ??= new Harmony("com.jakecool19.efrecipes.cookingoverhaul");
+            logger = api.Logger;
             harmony.PatchAll(Assembly.GetExecutingAssembly());
         }
 
@@ -120,6 +122,10 @@ namespace ACulinaryArtillery
                     }
                 }
             }
+        }
+
+        internal static void LogError(string message) {
+            logger.Error(message);
         }
 
     }

--- a/ACulinaryArtillery.csproj
+++ b/ACulinaryArtillery.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>netstandard2.0</TargetFramework>
+		<TargetFramework>net461</TargetFramework>
 		<LangVersion>9</LangVersion>
 		<ApplicationIcon />
 		<OutputType>Library</OutputType>
@@ -516,43 +516,43 @@
 
 	<ItemGroup>
 		<Reference Include="0Harmony">
-			<HintPath>..\..\..\AppData\Roaming\Vintagestory\Lib\0Harmony.dll</HintPath>
+			<HintPath>$(AppData)\Vintagestory\Lib\0Harmony.dll</HintPath>
 			<Private>false</Private>
 		</Reference>
 		<Reference Include="cairo-sharp">
-			<HintPath>..\..\..\AppData\Roaming\Vintagestory\Lib\cairo-sharp.dll</HintPath>
+			<HintPath>$(AppData)\Vintagestory\Lib\cairo-sharp.dll</HintPath>
 			<Private>false</Private>
 		</Reference>
 		<Reference Include="Newtonsoft.Json">
-			<HintPath>..\..\..\AppData\Roaming\Vintagestory\Lib\Newtonsoft.Json.dll</HintPath>
+			<HintPath>$(AppData)\Vintagestory\Lib\Newtonsoft.Json.dll</HintPath>
 			<Private>false</Private>
 		</Reference>
 		<Reference Include="protobuf-net">
-			<HintPath>..\..\..\AppData\Roaming\Vintagestory\Lib\protobuf-net.dll</HintPath>
+			<HintPath>$(AppData)\Vintagestory\Lib\protobuf-net.dll</HintPath>
 			<Private>false</Private>
 		</Reference>
 		<Reference Include="VintagestoryAPI">
-			<HintPath>..\..\..\AppData\Roaming\Vintagestory\VintagestoryAPI.dll</HintPath>
+			<HintPath>$(AppData)\Vintagestory\VintagestoryAPI.dll</HintPath>
 			<Private>false</Private>
 		</Reference>
 		<Reference Include="VintagestoryLib">
-			<HintPath>..\..\..\AppData\Roaming\Vintagestory\VintagestoryLib.dll</HintPath>
+			<HintPath>$(AppData)\Vintagestory\VintagestoryLib.dll</HintPath>
 			<Private>false</Private>
 		</Reference>
 		<Reference Include="VSBuildLib">
-			<HintPath>..\..\..\AppData\Roaming\Vintagestory\VSBuildLib.dll</HintPath>
+			<HintPath>$(AppData)\Vintagestory\VSBuildLib.dll</HintPath>
 			<Private>false</Private>
 		</Reference>
 		<Reference Include="VSCreativeMod">
-			<HintPath>..\..\..\AppData\Roaming\Vintagestory\Mods\VSCreativeMod.dll</HintPath>
+			<HintPath>$(AppData)\Vintagestory\Mods\VSCreativeMod.dll</HintPath>
 			<Private>false</Private>
 		</Reference>
 		<Reference Include="VSEssentials">
-			<HintPath>..\..\..\AppData\Roaming\Vintagestory\Mods\VSEssentials.dll</HintPath>
+			<HintPath>$(AppData)\Vintagestory\Mods\VSEssentials.dll</HintPath>
 			<Private>false</Private>
 		</Reference>
 		<Reference Include="VSSurvivalMod">
-			<HintPath>..\..\..\AppData\Roaming\Vintagestory\Mods\VSSurvivalMod.dll</HintPath>
+			<HintPath>$(AppData)\Vintagestory\Mods\VSSurvivalMod.dll</HintPath>
 			<Private>false</Private>
 		</Reference>
 	</ItemGroup>

--- a/Util/HarmonyPatchHelpers.cs
+++ b/Util/HarmonyPatchHelpers.cs
@@ -1,0 +1,66 @@
+﻿using HarmonyLib;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection.Emit;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ACulinaryArtillery.Util {
+    public static class CodeMatcherExtensions {
+
+        /// <summary>
+        /// Extracts the current position out of a <see cref="CodeMatcher"/>.
+        /// </summary>
+        public static CodeMatcher RememberPositionIn(this CodeMatcher matcher, out int position) {
+            position = matcher.Pos;
+            return matcher;
+        }
+
+        /// <summary>
+        /// Extracts the <see cref="CodeMatcher.NamedMatch(string)"/> out of a <see cref="CodeMatcher"/>.
+        /// </summary>
+        public static CodeMatcher RememberNamedMatchIn(this CodeMatcher matcher, string name, out CodeInstruction instruction) {
+            instruction = matcher.NamedMatch(name);
+            return matcher;
+        }
+
+        /// <summary>
+        /// Extracts the current <see cref="Instruction"/> out of a <see cref="CodeMatcher"/>.
+        /// </summary>
+        public static CodeMatcher RememberInstructionIn(this CodeMatcher matcher, out CodeInstruction instruction) {
+            instruction = matcher.Instruction;
+            return matcher;
+        }
+
+
+    }
+
+    public static class Instruction {
+        public static bool IsBrFalse(this CodeInstruction ci)
+            => ci.opcode == OpCodes.Brfalse || ci.opcode == OpCodes.Brfalse_S;
+
+        public static bool IsBrTrue(this CodeInstruction ci)
+            => ci.opcode == OpCodes.Brtrue || ci.opcode == OpCodes.Brtrue_S;
+
+        public static bool IsBr(this CodeInstruction ci)
+            => ci.opcode == OpCodes.Br || ci.opcode == OpCodes.Br_S;
+
+        public static bool IsCallVirt(this CodeInstruction ci, MethodBase target = null)
+            => target != null
+                ? ci.opcode == OpCodes.Callvirt && ci.operand as MethodBase == target
+                : ci.opcode == OpCodes.Callvirt;
+
+        public static bool IsLdLoc(this CodeInstruction ci, Func<LocalBuilder, bool> predicate = null)
+            => (ci.opcode == OpCodes.Ldloc || ci.opcode == OpCodes.Ldloc_S)
+                && ci.operand is LocalBuilder lb
+                && (predicate?.Invoke(lb) ?? true);
+
+        public static bool IsLdLoc(this CodeInstruction ci, Type localType)
+            => ci.IsLdLoc(lb => lb.LocalType == localType);
+
+        public static bool IsInst(this CodeInstruction ci, Type type)
+            => ci.opcode == OpCodes.Isinst && ci.operand as Type == type;
+    }
+}

--- a/Util/Patches.cs
+++ b/Util/Patches.cs
@@ -32,6 +32,35 @@ namespace ACulinaryArtillery
                 __result = (__instance[1].Itemstack.Collectible as BlockSaucepan).GetOutputText(__instance.Api.World, __instance);
             }
         }
+
+
+        /// <summary>
+        /// Turns the
+        /// <code>
+        ///     ...
+		///	    if (targetSlot == this.slots[1] && (stack.Collectible is BlockSmeltingContainer || stack.Collectible is BlockCookingContainer))
+		///	    {
+        ///	        ...
+		///	    }  
+        ///	    ...
+        /// </code>
+        /// block
+        /// into
+        /// <code>
+        ///     ...
+		///	    if (targetSlot == this.slots[1] && (stack.Collectible is BlockSmeltingContainer || stack.Collectible is BlockSaucePan || stack.Collectible is BlockCookingContainer))
+		///	    {
+        ///	        ...
+		///	    }  
+        ///	    ...
+        /// </code>
+        /// to make saucepans/cauldrons prefer a firepit's input slot.
+        /// </summary>
+        [HarmonyPatch(nameof(InventorySmelting.GetSuitability))]
+        [HarmonyTranspiler]
+        public static IEnumerable<CodeInstruction> AddSaucePanToPrefereedSmeltingInputs(IEnumerable<CodeInstruction> instructions) {
+            return instructions;
+        }
     }
 
     [HarmonyPatch(typeof(CookingRecipeIngredient))]


### PR DESCRIPTION
Makes the saucepan/cauldron prefer the input slot of firepits (like cooking pots) - in effect allowing you to shift-left click cauldrons into the firepit.

[![IMAGE Shift click cauldron into firepit](http://img.youtube.com/vi/phyFejnHHBk/0.jpg)](http://www.youtube.com/watch?v=phyFejnHHBkE "Cauldron interaction")

---

Is kinda using (and expands on) some of the helper extensions for #2. So maybe hold back on merging this until that one is done and dry. Then I can merge things together nicely.