### PR TITLE
Simplified(?) egg cracking 🥚 🔨

### DIFF
--- a/ACulinaryArtillery.cs
+++ b/ACulinaryArtillery.cs
@@ -125,7 +125,7 @@ namespace ACulinaryArtillery
         }
 
         internal static void LogError(string message) {
-            logger.Error(message);
+            logger.Error("(ACulinaryArtillery): {0}", message);
         }
 
     }

--- a/ACulinaryArtillery.csproj
+++ b/ACulinaryArtillery.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net461</TargetFramework>
+		<TargetFramework>net462</TargetFramework>
 		<LangVersion>9</LangVersion>
 		<ApplicationIcon />
 		<OutputType>Library</OutputType>
@@ -515,6 +515,10 @@
 	</ItemGroup>
 
 	<ItemGroup>
+	  <PackageReference Include="System.ValueTuple" Version="4.5.0" />
+	</ItemGroup>
+
+	<ItemGroup>
 		<Reference Include="0Harmony">
 			<HintPath>$(AppData)\Vintagestory\Lib\0Harmony.dll</HintPath>
 			<Private>false</Private>
@@ -537,10 +541,6 @@
 		</Reference>
 		<Reference Include="VintagestoryLib">
 			<HintPath>$(AppData)\Vintagestory\VintagestoryLib.dll</HintPath>
-			<Private>false</Private>
-		</Reference>
-		<Reference Include="VSBuildLib">
-			<HintPath>$(AppData)\Vintagestory\VSBuildLib.dll</HintPath>
 			<Private>false</Private>
 		</Reference>
 		<Reference Include="VSCreativeMod">

--- a/Item/ItemEggCrack.cs
+++ b/Item/ItemEggCrack.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using Vintagestory.API.Client;
 using Vintagestory.API.Common;
 using Vintagestory.API.Common.Entities;
+using Vintagestory.API.Config;
 using Vintagestory.API.MathTools;
 using Vintagestory.API.Util;
 using Vintagestory.GameContent;
@@ -65,30 +66,99 @@ namespace ACulinaryArtillery
             return null;
         }
 
+        /// <summary>
+        /// <para>
+        /// Utility method to determine if and how to add a liquid to a target. 
+        /// </para> 
+        /// <para>
+        /// Eliminates repetitions (and issues) across <see cref="OnHeldInteractStart(ItemSlot, EntityAgent, BlockSelection, EntitySelection, bool, ref EnumHandHandling)"/>
+        /// &amp; <see cref="OnHeldInteractStop(float, ItemSlot, EntityAgent, BlockSelection, EntitySelection)"/>
+        /// </para>
+        /// </summary>
+        /// <param name="block">Targeted block</param>
+        /// <param name="pos">Targeted position</param>
+        /// <param name="selection">Targeted block selection</param>
+        /// <param name="targetStack">Stack the liquid will be added to. Will be <see langword="null" /> if the targeted container/bowl/etc is currently empty.</param>
+        /// <param name="tryAddLiquidAction">
+        /// <para>
+        /// Callback to use to actually <em>add</em> the liquid. Will correctly switch between container &amp; ground based targets. Will mark target dirty is liquid was added.
+        /// </para>
+        /// <para>
+        /// Callback will return <see langword="false"/> if no liquid was actually added (for example if the container was full), <see langword="true"/> otherwise.</para>
+        /// </param>
+        /// <returns>
+        /// <see langword="true"/> if liquid can be added for the <paramref name="block"/>, <paramref name="pos"/> &amp; <paramref name="selection"/>; 
+        /// <see langword="false"/> if there is no container to add liquid to (direct or as ground storage) <em>or</em> if the targeted container is full 
+        /// (see <see cref="ItemHoneyComb.CanSqueezeInto(Block, BlockPos)" />).
+        /// </returns>
+        /// <remarks>
+        /// <em>Note:</em> This implementation <em>differs</em> from the default (honeycomb) target selection. Vanilla will always pick the "first available" ground stored 
+        /// container. This implementation will pick the <em>targeted</em> container on the ground, and only if that is unavailable it will pick a "first available" fallback.
+        /// </remarks>
+        public bool CanAddLiquid(Block block, BlockPos pos, BlockSelection selection, out ItemStack targetStack, out System.Func<ItemStack, float, bool> tryAddLiquidAction) {
+            if (block is BlockLiquidContainerTopOpened blcto && (pos == null || !blcto.IsFull(pos))) {
+                targetStack = blcto.GetContent(pos);
+                tryAddLiquidAction = (liquid, amount) => blcto.TryPutLiquid(pos, liquid, amount) != 0;
+                return true;
+            }
+            if (pos != null) {
+
+                // improve on vanilla implementation: dont just pick "first available" block, go with target selection, *then* first available
+                bool IsSuitableItemSlot(ItemSlot slot) {
+                    return slot.Itemstack?.Block is Block slotBlock && this.CanSqueezeInto(slotBlock, null);
+                }
+
+                ItemSlot PickTargetSlot(BlockEntityGroundStorage storage) {
+                    return storage.GetSlotAt(selection) is ItemSlot targetedSlot && IsSuitableItemSlot(targetedSlot)
+                        ? targetedSlot                                                                                  // pick what player has targeted if suitable
+                        : storage.Inventory.FirstOrDefault(IsSuitableItemSlot);                                         // otherwise pick first available
+                }
+
+                if (                    
+                    this.api.World.BlockAccessor.GetBlockEntity(pos) is BlockEntityGroundStorage beg                    // there is a ground storage
+                    && PickTargetSlot(beg) is ItemSlot targetSlot                                                       // pick a target slot
+                    && targetSlot.Itemstack is ItemStack squeezeStack                                                   // remember the itemstack 
+                    && squeezeStack.Block is BlockLiquidContainerTopOpened groundBltco                                  // grab the 'container'
+                    && !groundBltco.IsFull(targetSlot.Itemstack)                                                        // make sure it's not full
+                ) {
+                    targetStack = targetSlot.Itemstack?.Attributes?.GetTreeAttribute("contents")?.GetItemstack("0");
+                    tryAddLiquidAction = (liquid, amount) => {
+                        // note how the put liquid action uses a *different* overload than for the direct injection - see also <see cref="ItemHoneyComb.OnHeldInteractStop" />
+                        bool success = groundBltco.TryPutLiquid(squeezeStack, liquid, amount) != 0;
+                        // embed the dirtying into the "add liquid" action
+                        if (success)
+                            beg.MarkDirty(true);
+                        return success;
+                    };
+                    return true;
+                }
+            }
+            targetStack = null;
+            tryAddLiquidAction = (_, __) => false;
+            return false;
+        }
+
         public override void OnHeldInteractStart(ItemSlot slot, EntityAgent byEntity, BlockSelection blockSel, EntitySelection entitySel, bool firstEvent, ref EnumHandHandling handling)
         {
             if (blockSel == null || !byEntity.Controls.Sneak) return;
 
             byEntity.AnimManager.StartAnimation("eggcrackstart");
 
-            Block block = byEntity.World.BlockAccessor.GetBlock(blockSel.Position);
+            IBlockAccessor blockAccessor = byEntity.World.BlockAccessor;
+            Block block = blockAccessor.GetBlock(blockSel.Position);
 
-            CollectibleObject targetCollectible = api.World.BlockAccessor?.GetBlockEntity(blockSel.Position) switch {
-                BlockEntityGroundStorage groundStorage => groundStorage.Inventory.FirstOrDefault(slot => !slot.Empty)?.Itemstack?.Attributes?.GetTreeAttribute("contents")?.GetItemstack("0")?.Collectible,
-                BlockEntityLiquidContainer container => container.Inventory.FirstNonEmptySlot?.Itemstack.Collectible,
-                _ => null
-            };
+            bool canAddLiquid = CanAddLiquid(block, blockSel.Position, blockSel, out var targetStack, out var _);
 
             string eggType = slot.Itemstack.Collectible.FirstCodePart(0);      //grabs currently held item's code
             string eggVariant = slot.Itemstack.Collectible.FirstCodePart(1);   //grabs 1st variant in currently held item
 
-            bool canCrack = (targetCollectible, targetCollectible?.FirstCodePart(0), targetCollectible?.FirstCodePart(1)) switch {
-                (null, _, _)                            => false,                                                                                         // no collectible
-                (_, null, _)                            => CanSqueezeInto(block, blockSel.Position),                                                      // collectible empty
-                (_, "eggyolkfullportion", var yolk)     => byEntity.Controls.Sprint && (eggType == "egg" || eggType == "limeegg") && yolk == eggVariant,  // liquid egg in container, need to be full cracking, have right egg & matching yolks
-                (_, "eggwhiteportion", _)               => !byEntity.Controls.Sprint && (eggType == "egg" || eggType == "limeegg"),                       // egg white in container, partial cracking and right egg
-                (_, "eggyolkportion", var yolk)         => eggType == "eggyolk" && yolk == eggVariant,                                                    // yolk in container, need yolk of right type in hand
-                _ => false
+            bool canCrack = (canAddLiquid, targetStack, targetStack?.Collectible?.FirstCodePart(0), targetStack?.Collectible?.FirstCodePart(1)) switch {
+                (false, _, _, _)                            => false,                                                                                            // cant add liquid
+                (_, null, _, _)                             => true,                                                                                             // empty target stack - can always squeeze (CanAddLiquid already checks for CanSqueeze)
+                (_, _, "eggyolkfullportion", var yolk)      => byEntity.Controls.Sprint && (eggType == "egg" || eggType == "limeegg") && yolk == eggVariant,     // liquid egg in container, need to be full cracking, have right egg & matching yolks
+                (_, _, "eggwhiteportion", _)                => !byEntity.Controls.Sprint && (eggType == "egg" || eggType == "limeegg"),                          // egg white in container, partial cracking and right egg
+                (_, _, "eggyolkportion", var yolk)          => eggType == "eggyolk" && yolk == eggVariant,                                                       // yolks - egg variant must match
+                _                                           => false
             };
 
             if (canCrack) {         //move to OnHeldInteractStep & play eggcrack.ogg
@@ -143,8 +213,8 @@ namespace ACulinaryArtillery
             byEntity.AnimManager.StopAnimation("eggcrackstart");
 
             IWorldAccessor world = byEntity.World;
-
-            Block block = byEntity.World.BlockAccessor.GetBlock(blockSel.Position);
+            IBlockAccessor blockAccessor = world.BlockAccessor;
+            Block block = blockAccessor.GetBlock(blockSel.Position);
             if (!CanSqueezeInto(block, blockSel.Position)) return;
 
             string eggType = slot.Itemstack.Collectible.FirstCodePart(0);   //grabs currently held item's code
@@ -160,29 +230,21 @@ namespace ACulinaryArtillery
             ItemStack eggYolkFullStack = new ItemStack(world.GetItem(new AssetLocation(eggYolkFullLiquidAsset)), 99999);
             ItemStack stack = new ItemStack(world.GetItem(new AssetLocation(eggShellOutput)));
 
-
-            BlockLiquidContainerTopOpened receptacle = null;
-            BlockEntityGroundStorage groundStorage = null;
-            if (block is BlockLiquidContainerTopOpened bltoDirect) {
-                receptacle = bltoDirect;
-                groundStorage = null;
-            } else { 
-                groundStorage = api.World.BlockAccessor.GetBlockEntity(blockSel.Position) as BlockEntityGroundStorage;
-                receptacle = groundStorage?.Inventory.FirstOrDefault(gslot => gslot.Itemstack?.Block != null && CanSqueezeInto(gslot.Itemstack.Block, null))?.Itemstack.Block as BlockLiquidContainerTopOpened;
-            };
+            bool canAddLiquid = CanAddLiquid(block, blockSel.Position, blockSel, out var _, out var tryPutLiquid);
+            if (!canAddLiquid)
+                return;
 
             (ItemStack liquid, bool giveYolk) = (byEntity.Controls.Sprint, eggType) switch {
                 (true, "egg") or
-                (true, "limeegg")   => (eggYolkFullStack, false),
+                (true, "limeegg")       => (eggYolkFullStack, false),
                 (false, "egg") or
-                (false, "limeegg")  => (eggWhiteStack, true),
-                (_, "eggyolk")      => (eggYolkStack, false),
-                _                   => (null, false)
+                (false, "limeegg")      => (eggWhiteStack, true),
+                (_, "eggyolk")          => (eggYolkStack, false),
+                _                       => (null, false)
             };
 
-            if (liquid != null) {
-                receptacle?.TryPutLiquid(blockSel.Position, liquid, ContainedEggLitres);
-                groundStorage?.MarkDirty(true);
+            if (liquid != null && !tryPutLiquid(liquid, ContainedEggLitres)) {
+                return;                
             }
 
             if (api.World.Side == EnumAppSide.Client) {

--- a/Item/ItemEggCrack.cs
+++ b/Item/ItemEggCrack.cs
@@ -91,13 +91,7 @@ namespace ACulinaryArtillery
         /// <param name="block"><em>Optional</em> targeted block. If <see langword="null" /> is passed, will use <paramref name="accessor"/> to get the block for <paramref name="selection"/>. 
         /// If callers have already retrieved the block (or need it for later processing anyway) can be supplied to cut down on block accessor usage.</param>
         /// <param name="blockEntity"><em>Optional</em> targeted block entity. If <see langword="null" /> is passed, will use <paramref name="accessor"/> to get the block entity for <paramref name="selection"/>. 
-        /// If callers have already retrieved the block entity (or need it for later processing anyway) can be supplied to cut down on block accessor usage.</param>
-        /// <param name="tryAddLiquidAction">
-        /// <para>
-        /// Callback to use to actually <em>add</em> the liquid. Will correctly switch between container &amp; ground based targets. Will mark target dirty is liquid was added.
-        /// </para>
-        /// <para>
-        /// Callback will return <see langword="false"/> if no liquid was actually added (for example if the container was full), <see langword="true"/> otherwise.</para>
+        /// If callers have already retrieved the block entity (or need it for later processing anyway) can be supplied to cut down on block accessor usage.
         /// </param>
         /// <returns>
         /// <list type="bullet">

--- a/Properties/launchSettings.json
+++ b/Properties/launchSettings.json
@@ -1,9 +1,10 @@
 {
   "profiles": {
-    "ACulinaryArtillery": {
-      "commandName": "Project",
-      "commandLineArgs": "--addModPath=\"C:\\Users\\Tyler\\source\\repos\\ACulinaryArtillery--l33tFork\\bin\\Debug\" --addOrigin=\"C:\\Users\\Tyler\\source\\repos\\ACulinaryArtillery--l33tFork\\assets\"",
-      "workingDirectory": "C:\\Users\\Tyler\\AppData\\Roaming\\Vintagestory"
+    "VintageStory": {
+      "commandName": "Executable",
+      "executablePath": "$(APPDATA)\\VintageStory\\VintageStory.exe",
+      "commandLineArgs": "-openWorld=\"modsamplestest\" -pcreativebuilding",
+      "workingDirectory": "$(APPDATA)\\VintageStory\\"
     }
   }
 }

--- a/Util/HarmonyPatchHelpers.cs
+++ b/Util/HarmonyPatchHelpers.cs
@@ -6,6 +6,8 @@ using System.Reflection.Emit;
 using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
 
 namespace ACulinaryArtillery.Util {
     public static class CodeMatcherExtensions {
@@ -60,7 +62,131 @@ namespace ACulinaryArtillery.Util {
         public static bool IsLdLoc(this CodeInstruction ci, Type localType)
             => ci.IsLdLoc(lb => lb.LocalType == localType);
 
+        public static bool IsLdLoc(this CodeInstruction ci)
+            => ci.opcode == OpCodes.Ldloc_0
+                || ci.opcode == OpCodes.Ldloc_1
+                || ci.opcode == OpCodes.Ldloc_2
+                || ci.opcode == OpCodes.Ldloc_3
+                || IsLdLoc(ci);
+
+        public static bool IsStLoc(this CodeInstruction ci, Func<LocalBuilder, bool> predicate = null)
+            => (ci.opcode == OpCodes.Stloc || ci.opcode == OpCodes.Stloc_S)
+                && ci.operand is LocalBuilder lb
+                && (predicate?.Invoke(lb) ?? true);
+
+        public static bool IsStLoc(this CodeInstruction ci, Type localType)
+            => ci.IsStLoc(lb => lb.LocalType == localType);
+
+        public static bool IsAnyStLoc(this CodeInstruction ci)
+            => ci.opcode == OpCodes.Stloc_0
+                || ci.opcode == OpCodes.Stloc_1
+                || ci.opcode == OpCodes.Stloc_2
+                || ci.opcode == OpCodes.Stloc_3
+                || IsStLoc(ci);
+
         public static bool IsInst(this CodeInstruction ci, Type type)
             => ci.opcode == OpCodes.Isinst && ci.operand as Type == type;
     }
+
+    /// <summary>
+    /// Helper class to allow easy(ish) replacements of local uses by type.
+    /// </summary>
+    public class LocalRedirector {
+
+        private LocalRedirector() {
+        }
+
+        /// <summary>
+        /// The singleton to use for access.
+        /// </summary>
+        public static LocalRedirector Instance { get; } = new LocalRedirector();
+
+        /// <summary>
+        /// Factories to replace all <c>[St|Ld]loc[_(0|1|2|3)|S] [operand]</c> instructions with <c>[St|Ld]loc [targetLocalBuilder]</c>
+        /// </summary>
+        private static IDictionary<OpCode, (OpCode Store, OpCode Load, System.Func<LocalBuilder, object, (Predicate<CodeInstruction> Matcher, Action<CodeInstruction> Mutator)> Factory, bool CaptureOperand)> localRewriterFactories =
+           new (OpCode Store, OpCode Load, bool CaptureLocal)[] {
+                // all relevant store/load tuples
+                (OpCodes.Stloc, OpCodes.Ldloc, true),
+                (OpCodes.Stloc_S, OpCodes.Ldloc_S, true),
+                (OpCodes.Stloc_0, OpCodes.Ldloc_0, false),
+                (OpCodes.Stloc_1, OpCodes.Ldloc_1, false),
+                (OpCodes.Stloc_2, OpCodes.Ldloc_2, false),
+                (OpCodes.Stloc_3, OpCodes.Ldloc_3, false),
+           }
+           .ToDictionary(
+               t => t,
+               // create matchers & mutators for each tuple
+               t => (System.Func<LocalBuilder, object, (Predicate<CodeInstruction> Matcher, Action<CodeInstruction> Mutator)>)(
+                    (LocalBuilder lb, object operand) => {
+                        Predicate<CodeInstruction> simpleMatcher = ci => ci.opcode == t.Store || ci.opcode == t.Load;
+                        return (
+                            Matcher: t.CaptureLocal
+                                ? ci => simpleMatcher(ci) && ci.operand == operand
+                                : simpleMatcher,
+                            Mutator: ci => {
+                                ci.operand = lb;
+                                ci.opcode = ci.opcode == t.Store
+                                    ? OpCodes.Stloc
+                                    : OpCodes.Ldloc;
+                            }
+                        );
+                    })
+            ).SelectMany(
+               // flatten list by duplicating via both store & load opcodes per tuple
+               kvp => new[] { 
+                   (kvp.Key.Load, kvp.Key, kvp.Value, kvp.Key.CaptureLocal), 
+                   (kvp.Key.Store, kvp.Key, kvp.Value, kvp.Key.CaptureLocal) 
+               }
+            ).ToDictionary(
+               // make a new dictionary indexed by each opcode
+               t => t.Item1,
+               t => (Store: t.Key.Store, Load: t.Key.Load, Factory: t.Value, CaptureOperand: t.CaptureLocal)
+            );
+
+        /// <summary>
+        /// Returns a nullable tuple of helpers to find &amp; change usages of the locals referenced by <paramref name="instruction"/>
+        /// with elements:
+        /// <list type="table">
+        /// <item>
+        /// <term>Matcher</term>
+        /// <description>A <see cref="Predicate{CodeInstruction}" /> that will match any use of the same local variable as referenced by 
+        /// <see cref="Instruction"/>'s <see cref="CodeInstruction.opcode" />, either for storage or retrieval.</description>
+        /// </item>
+        /// <item>
+        /// <term>Mutator</term>
+        /// <description><para>An <see cref="Action{CodeInstruction}"/> that will change an instructon to use <paramref name="targetLocalBuilder"/> 
+        /// instead of the local from <see cref="Instruction"/>'s <see cref="CodeInstruction.opcode"/>.
+        /// </para>
+        /// <para>
+        /// Note that this action will <em>blindly</em> replace the members of passed in instructions. If that is not intended, filter first (for 
+        /// example via the Matcher).
+        /// </para>
+        /// </description>
+        /// </item>
+        /// <item>
+        /// <term>CapturesOperand</term>
+        /// <description>A flag that indicates if the <paramref name="instruction"/>'s <see cref="CodeInstruction.operand"/> is captured by 
+        /// the Matcher and Mutator members (shortform <see cref="OpCode"/>s like <see cref="OpCodes.Ldarg_0"/>, <see cref="OpCodes.Stloc_1" />, etc.)
+        /// don't use an operand. Longform variants like <see cref="OpCodes.Ldloc" /> or <see cref="OpCodes.Stloc_S" /> do.
+        /// </description>
+        /// </item>
+        /// </list>
+        /// </summary>
+        /// <param name="instruction">Instruction to create helpers for.</param>
+        /// <param name="targetLocalBuilder">Local builder to redirect local usages to.</param>
+        /// <remarks>Result will be <see langword="null" /> if <paramref name="instruction"/> is not a <see cref="OpCodes.Ldloc"/>/<see cref="OpCodes.Stloc"/>
+        /// like instruction.</remarks>
+        public (Predicate<CodeInstruction> Matcher, Action<CodeInstruction> Mutator, bool CapturesOperand)? this[CodeInstruction instruction, LocalBuilder targetLocalBuilder] {
+            get {
+                if (localRewriterFactories.TryGetValue(instruction.opcode, out var entry)) {
+                    var (matcher, mutator) = entry.Factory(targetLocalBuilder, entry.CaptureOperand ? instruction.operand : null);
+                    return (matcher, mutator, entry.CaptureOperand);
+                } 
+                return null;
+                
+            }
+        }
+    }
+
 }

--- a/Util/MathHelper.cs
+++ b/Util/MathHelper.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading.Tasks;
+
+using Vintagestory.API.MathTools;
+
+namespace ACulinaryArtillery.Util {
+    internal static class MathHelper {
+
+        public static Vec3f Center(this Cuboidf cubeoid) {
+            return new Vec3f(cubeoid.MidX, cubeoid.MidY, cubeoid.MidZ);
+        }
+
+        public static Vec2f XZSize(this Cuboidf cubeoid) {
+            return new Vec2f(cubeoid.Width, cubeoid.Height);
+        }
+
+        public static Vec2f ToXZ(this Vec3f v)
+            => new Vec2f(v.X, v.Z);
+
+
+        public static void Deconstruct(this Vec2f v, out double a, out double b) {
+            a = v.X;
+            b = v.Y;
+        }
+
+        /// <summary>
+        /// <para>
+        /// Returns the intersection of a line from the point <paramref name="point"/>.<see cref=""/>
+        /// (<paramref name="point"/>.<see cref="Vec3f.X">X</see>, <paramref name="point"/>.<see cref="Vec3f.Z">Z</see>) 
+        /// going through the center of an ellipses at (<paramref name="box"/>.<see cref="Cuboidf.MidX">MidX</see>, <paramref name="box"/>.<see cref="Cuboidf.MidZ">MidZ</see>)
+        /// with semiaxes <paramref name="box" />.<see cref="Cuboidf.Width">Width/2</see> &amp; <paramref name="box"/>.<see cref="Cuboidf.Length">Length/2</see> closest to
+        /// <paramref name="point"/> in the X/Z plane at a height of <paramref name="box"/>.<see cref="Cuboidf.MaxY">MaxY</see>.
+        /// </para>
+        /// <para>In short terms: What's the point on the ellipses that's closest to <paramref name="point"/>.</para>
+        /// </summary>
+        /// <param name="box">Cube to use</param>
+        /// <param name="point">Point to use</param>
+        /// <returns></returns>
+        public static Vec3d TopFaceEllipsesLineIntersection(this Cuboidf box, Vec3f point) {
+            var (a, b) = box.XZSize() / 2;
+
+            Vec3f cubeCenter = box.Center();
+            var (x, z) = point.ToXZ() - cubeCenter.ToXZ();
+
+            double ab = a * b;
+            double d = Math.Sqrt(a * a * z * z + b * b * x * x);
+
+            double f = ab / d;
+
+            return new Vec3d(f * x, 0, f * z);
+        }
+
+    }
+}

--- a/Util/MathHelper.cs
+++ b/Util/MathHelper.cs
@@ -39,7 +39,7 @@ namespace ACulinaryArtillery.Util {
         /// </summary>
         /// <param name="box">Cube to use</param>
         /// <param name="point">Point to use</param>
-        /// <returns></returns>
+        /// <seealso href="https://mathworld.wolfram.com/Ellipse-LineIntersection.html"/>
         public static Vec3d TopFaceEllipsesLineIntersection(this Cuboidf box, Vec3f point) {
             var (a, b) = box.XZSize() / 2;
 

--- a/Util/Patches.cs
+++ b/Util/Patches.cs
@@ -449,15 +449,14 @@ namespace ACulinaryArtillery
 
             /// <summary>
             /// This is <em>kind of</em> a prefix for <see cref="ItemHoneyComb.CanSqueezeInto(Block, BlockPos)"/>, but it uses a different 
-            /// set of parameters. Still partially shadows call into there.
+            /// set of parameters. Still partially shadows calls into there.
             /// </summary>
             public static bool CanSqueezeInto(ItemHoneyComb instance, Block block, BlockSelection selection) {
                 return block switch {
                     ILiquidSink => instance.CanSqueezeInto(block, selection.Position),
                     _ => apiAccessor(instance) is var api
                         && api.World.BlockAccessor.GetBlockEntity(selection.Position) is BlockEntityGroundStorage beg
-                        && instance.GetSuitableTargetSlot(beg, selection) is ItemSlot slot
-                        && !(slot.Itemstack.Block as ILiquidSink).IsFull(slot.Itemstack)
+                        && instance.GetSuitableTargetSlot(beg, selection) is ItemSlot
                 };
             }
 

--- a/Util/SqueezeHelper.cs
+++ b/Util/SqueezeHelper.cs
@@ -5,26 +5,133 @@ using System.Text;
 using System.Threading.Tasks;
 
 using Vintagestory.API.Common;
+using Vintagestory.API.MathTools;
 using Vintagestory.GameContent;
 
 namespace ACulinaryArtillery.Util {
+    /// <summary>
+    /// <para>
+    /// A callback to use to add liquid to a targeted container.
+    /// </para>
+    /// </summary>
+    /// <remarks>Will also mark <see cref="BlockEntityGroundStorage"/> as dirty if applicable and liquid is added.</remarks>
+    /// <param name="liquid">Liquid to add.</param>
+    /// <param name="amount">Amount to add.</param>
+    /// <returns><see langword="true" /> if any amount of liquid is added; <see langword="false"/> otherwise.</returns>
+    public delegate bool TryAddLiquidHandler(ItemStack liquid, float amount);
+
     public static class SqueezeHelper {
 
+        /// <summary>
+        /// Checks if <paramref name="slot"/> is suitable to squeeze liquids in there. Includes a check for <see cref="ILiquidInterface.IsFull(ItemStack)"/>.
+        /// </summary>
+        /// <param name="instance">Instance to check for.</param>
+        /// <param name="slot">Slot to check</param>
         public static bool IsSuitableItemSlot(this ItemHoneyComb instance, ItemSlot slot) {
-            return slot.Itemstack?.Block is Block slotBlock && instance.CanSqueezeInto(slotBlock, null);
+            return slot.Itemstack?.Block is Block slotBlock
+                && instance.CanSqueezeInto(slotBlock, null)
+                && (slotBlock as ILiquidSink)?.IsFull(slot.Itemstack) == false;
         }
 
         /// <summary>
         /// Similar implementation as <see cref="ItemHoneyComb.CanSqueezeInto(Block, Vintagestory.API.MathTools.BlockPos)"/> but actually uses 
-        /// <paramref name="selection"/> to try to grab a targeted slot before defaulting to the "first available".
+        /// <paramref name="selection"/> to try to grab a targeted slot before defaulting to the "first available". Also implicitly checks if the target slot 
+        /// is already full so we dont pick a "suitable" spot to only later reject it because it has no room.
         /// </summary>
         /// <param name="storage">ground storage</param>
         /// <param name="selection">selection</param>
         /// <param name="instance">honey comb instance</param>
+        /// <seealso cref="IsSuitableItemSlot"/>
         public static ItemSlot GetSuitableTargetSlot(this ItemHoneyComb instance, BlockEntityGroundStorage storage, BlockSelection selection) {
             return storage.GetSlotAt(selection) is ItemSlot targetedSlot && instance.IsSuitableItemSlot(targetedSlot)
                 ? targetedSlot                                                                                  // pick what player has targeted if suitable
                 : storage.Inventory.FirstOrDefault(instance.IsSuitableItemSlot);                                // otherwise pick first available
+        }
+
+        /// <summary>
+        /// <para>
+        /// Utility method to determine if &amp; how to add a liquid to a target and what is potentially already in there.
+        /// </para> 
+        /// <para>
+        /// Eliminates repetitions (and issues) across <see cref="OnHeldInteractStart(ItemSlot, EntityAgent, BlockSelection, EntitySelection, bool, ref EnumHandHandling)"/>
+        /// &amp; <see cref="OnHeldInteractStop(float, ItemSlot, EntityAgent, BlockSelection, EntitySelection)"/>
+        /// </para>
+        /// </summary>
+        /// <param name="accessor">Block accessor to use</param>
+        /// <param name="selection">Targeted block selection</param>
+        /// <param name="block"><em>Optional</em> targeted block. If <see langword="null" /> is passed, will use <paramref name="accessor"/> to get the block for <paramref name="selection"/>. 
+        /// If callers have already retrieved the block (or need it for later processing anyway) can be supplied to cut down on block accessor usage.</param>
+        /// <param name="blockEntity"><em>Optional</em> targeted block entity. If <see langword="null" /> is passed, will use <paramref name="accessor"/> to get the block entity for <paramref name="selection"/>. 
+        /// If callers have already retrieved the block entity (or need it for later processing anyway) can be supplied to cut down on block accessor usage.
+        /// </param>
+        /// <returns>
+        /// <list type="bullet">
+        /// <item><see langword="null"/> if there is no suitable container (direct or via ground storage) to add liquids to</item>
+        /// <item>otherwise a tuple with members 
+        /// <list type="table">
+        /// <item>
+        /// <term>ExistingStack</term>
+        /// <description>The <see cref="ItemStack"/> currently existing inside the targeted liquid container. Will be <see langword="null"/> if the targeted container is empty.</description>
+        /// </item>
+        /// <item>
+        /// <term>TryAddLiquid</term>
+        /// <description>A callback to use to try adding liquid to the targeted container. See also <seealso cref="TryAddLiquidHandler"/></description>
+        /// </item>
+        /// <item>
+        /// <term>TargetBlock (preliminary)</term>
+        /// <description>The block belonging to the selected target stack. (Intended for animation use).</description>
+        /// </item>
+        /// </list>
+        /// </item>
+        /// </list>
+        /// </returns>
+        /// <remarks>
+        /// <em>Note:</em> This implementation <em>differs</em> from the default (honeycomb) target selection. Vanilla will always pick the "first available" ground stored 
+        /// container. This implementation will pick the <em>targeted</em> container on the ground, and only if that is unavailable it will pick a "first available" fallback.
+        /// </remarks>
+        public static (ItemStack ExistingStack, TryAddLiquidHandler TryAddLiquid, Block TargetBlock)? GetLiquidOptions(
+            this ItemHoneyComb instance,
+            IBlockAccessor accessor, 
+            BlockSelection selection, 
+            Block block = null, 
+            BlockEntity blockEntity = null) {
+
+            BlockPos pos = selection.Position;
+
+            return (block ?? accessor.GetBlock(pos), blockEntity ?? accessor.GetBlockEntity(pos), pos) switch {
+                // not into sealed saucepans
+                (_, BlockEntitySaucepan { isSealed : true}, _) => null,                                                    
+                // direct container 
+                (ILiquidSink { AllowHeldLiquidTransfer: true } sink, _, var p)
+                    when p == null || !sink.IsFull(p) => (
+                        ExistingStack: sink.GetContent(p),
+                        TryAddLiquid: (liquid, amount) => sink.TryPutLiquid(p, liquid, amount) != 0,
+                        TargetBlock: (Block)sink
+                    ),
+                // no position - no other options
+                (_, _, null) => null,
+                // we have a position, and are looking at a ground storage
+                (_, BlockEntityGroundStorage groundStorage, _) 
+                    when instance.GetSuitableTargetSlot(groundStorage, selection) is ItemSlot groundSlot                    // we have a target slot
+                        && groundSlot.Itemstack is ItemStack groundStack                                                    // (remember the itemstack) 
+                        && groundStack.Block is ILiquidSink { AllowHeldLiquidTransfer: true } sinkInGroundStack             // ensure its a valid liquid sink and remember it
+                            => sinkInGroundStack switch { 
+                                BlockEntitySaucepan { isSealed: true} => null,                                              // not int osealed saucepans
+                                _ => (
+                                    ExistingStack: groundStack?.Attributes?.GetTreeAttribute("contents")?.GetItemstack("0"),
+                                    TryAddLiquid: (liquid, amount) => {
+                                        // note how the put liquid action uses a *different* overload than for the direct injection - see also <see cref="ItemHoneyComb.OnHeldInteractStop" />
+                                        bool success = sinkInGroundStack.TryPutLiquid(groundStack, liquid, amount) != 0;
+                                        // embed the dirtying into the "add liquid" action
+                                        if (success)
+                                            groundStorage.MarkDirty(true);
+                                        return success;
+                                    },
+                                    TargetBlock: (Block)sinkInGroundStack
+                                ),
+                            },                                      
+                _ => null
+            };
         }
     }
 }

--- a/Util/SqueezeHelper.cs
+++ b/Util/SqueezeHelper.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using Vintagestory.API.Common;
+using Vintagestory.GameContent;
+
+namespace ACulinaryArtillery.Util {
+    public static class SqueezeHelper {
+
+        public static bool IsSuitableItemSlot(this ItemHoneyComb instance, ItemSlot slot) {
+            return slot.Itemstack?.Block is Block slotBlock && instance.CanSqueezeInto(slotBlock, null);
+        }
+
+        /// <summary>
+        /// Similar implementation as <see cref="ItemHoneyComb.CanSqueezeInto(Block, Vintagestory.API.MathTools.BlockPos)"/> but actually uses 
+        /// <paramref name="selection"/> to try to grab a targeted slot before defaulting to the "first available".
+        /// </summary>
+        /// <param name="storage">ground storage</param>
+        /// <param name="selection">selection</param>
+        /// <param name="instance">honey comb instance</param>
+        public static ItemSlot GetSuitableTargetSlot(this ItemHoneyComb instance, BlockEntityGroundStorage storage, BlockSelection selection) {
+            return storage.GetSlotAt(selection) is ItemSlot targetedSlot && instance.IsSuitableItemSlot(targetedSlot)
+                ? targetedSlot                                                                                  // pick what player has targeted if suitable
+                : storage.Inventory.FirstOrDefault(instance.IsSuitableItemSlot);                                // otherwise pick first available
+        }
+    }
+}


### PR DESCRIPTION
I ~~want to be able to~~ crack eggs into cauldrons. 

But to enable that I need to understand how the egg-cracking works.

So this is me refactoring the egg cracking logic.

I *think* this is way more maintainable. Eliminated several deeply branching repetitive (but not identical!) blocks and replaced them with a single custom method.
This _should_ be easier to follow.

Also added the ability to *target* which ground receptacle to crack into (before the game always picked "first available". Now you can choose which one).

![image](https://user-images.githubusercontent.com/324067/217328670-1cec9c6b-e796-488c-8ddd-c66a5e3afd49.png)

Other subtle change: Made the "no cracking" behaviour when target container is full consistent between bucket (or similar) targets & bowls. Now not just the bucket stops waste, the bowl does too. 
You can *also* successfully crack into jugs. As far as vanilla is concerned jugs are valid squeeze targets (because they have an open top). Pinging @MAGGen-hub here, since you merged a jug related change recently and I don't 100% understand what that did. Was cracking into jugs working incorrectly? Should it not have worked?

